### PR TITLE
Adjust ParameterType enum to be compliant with java coding convention

### DIFF
--- a/src/main/java/cz/upce/fei/inptp/zz/entity/ParameterType.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/entity/ParameterType.java
@@ -9,11 +9,9 @@ package cz.upce.fei.inptp.zz.entity;
  *
  * @author Roman
  */
-public enum ParameterTye {
-    Title,
-    Text,
-    Password,
-    Date
-    
-    
+public enum ParameterType {
+    TITLE,
+    TEXT,
+    PASSWORD,
+    DATE
 }

--- a/src/main/java/cz/upce/fei/inptp/zz/entity/Password.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/entity/Password.java
@@ -15,7 +15,7 @@ public class Password {
 
     private int id;
     private String password;
-    //private HashMap<ParameterTye, Parameter> parameters;
+    //private HashMap<ParameterType, Parameter> parameters;
     private HashMap<String, Parameter> parameters;
 
     public Password() {


### PR DESCRIPTION
Adjust enum name typo and field names of ParameterType to be compliant with name convention