### PR TITLE
Changed parameters hashmap key value type of class Password

### DIFF
--- a/src/main/java/cz/upce/fei/inptp/zz/entity/Password.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/entity/Password.java
@@ -15,8 +15,7 @@ public class Password {
 
     private int id;
     private String password;
-    //private HashMap<ParameterType, Parameter> parameters;
-    private HashMap<String, Parameter> parameters;
+    private HashMap<ParameterType, Parameter> parameters;
 
     public Password() {
     }
@@ -26,7 +25,7 @@ public class Password {
         this.password = password;
     }
 
-    public Password(int id, String password, HashMap<String, Parameter> parameters) {
+    public Password(int id, String password, HashMap<ParameterType, Parameter> parameters) {
         this.id = id;
         this.password = password;
         this.parameters = parameters;
@@ -40,18 +39,15 @@ public class Password {
         return password;
     }
 
-    public HashMap<String, Parameter> getParameters() {
+    public HashMap<ParameterType, Parameter> getParameters() {
         return parameters;
     }
 
-    boolean hasParameter(String TITLE) {
-        return parameters.containsKey(TITLE);
+    boolean hasParameter(ParameterType parameterType) {
+        return parameters.containsKey(parameterType);
     }
-    
-    public Parameter getParameter(String t) {
-        return parameters.get(t);
-    }
-    
-    
 
+    public Parameter getParameter(ParameterType parameterType) {
+        return parameters.get(parameterType);
+    }
 }

--- a/src/main/java/cz/upce/fei/inptp/zz/entity/PasswordDatabase.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/entity/PasswordDatabase.java
@@ -38,11 +38,10 @@ public class PasswordDatabase {
     
     public Password findEntryByTitle(String title) {
         for (Password password : passwords) {
-            
-            if (password.hasParameter(Parameter.StandardizedParameters.TITLE)) {
+            if (password.hasParameter(ParameterType.TITLE)) {
                 Parameter.TextParameter titleParam;
-                titleParam = (Parameter.TextParameter)password.getParameter(Parameter.StandardizedParameters.TITLE);
-                if (titleParam.getValue().equals(titleParam)) {
+                titleParam = (Parameter.TextParameter)password.getParameter(ParameterType.TITLE);
+                if (titleParam.getValue().equals(title)) {
                     return password;
                 }
             }


### PR DESCRIPTION
Dear Mr. Diviš,
I am sending you a patch of the project NNPTP20-2. In this patch, I have changed a key value type of the parameter 'parameters' of the class 'Password'. The reason of this change is, that the string parameter of the 'getParameter(string)' method can not be any string value anymore, but it is restricted to enum values only.

Thank you,
Michal Černota.