### PR TITLE
Equals method reworked at Password class.

### DIFF
--- a/src/main/java/cz/upce/fei/inptp/zz/entity/Password.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/entity/Password.java
@@ -62,15 +62,19 @@ public class Password {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Password)) return false;
-        Password password1 = (Password) o;
-        return id == password1.id &&
-                Objects.equals(password, password1.password) &&
-                Objects.equals(category, password1.category);
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final Password other = (Password) obj;
+        return id == other.id
+                && password.equals(other.password)
+                && category.equals(other.category);
     }
-
+    
     @Override
     public int hashCode() {
         return Objects.hash(id, password, category);

--- a/src/main/java/cz/upce/fei/inptp/zz/entity/Password.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/entity/Password.java
@@ -71,8 +71,8 @@ public class Password {
         }
         final Password other = (Password) obj;
         return id == other.id
-                && password.equals(other.password)
-                && category.equals(other.category);
+                && Objects.equals(password, other.password)
+                && Objects.equals(category, other.category);
     }
     
     @Override

--- a/src/main/java/cz/upce/fei/inptp/zz/entity/Password.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/entity/Password.java
@@ -74,7 +74,7 @@ public class Password {
                 && Objects.equals(password, other.password)
                 && Objects.equals(category, other.category);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(id, password, category);

--- a/src/test/java/cz/upce/fei/inptp/zz/entity/PasswordTest.java
+++ b/src/test/java/cz/upce/fei/inptp/zz/entity/PasswordTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
  * @author Roman
  */
 public class PasswordTest {
+    private Password password;
     
     public PasswordTest() {
     }
@@ -31,6 +32,7 @@ public class PasswordTest {
     
     @Before
     public void setUp() {
+        password = new Password(1, "abcd%123");
     }
     
     @After
@@ -38,11 +40,18 @@ public class PasswordTest {
     }
 
     @Test
-    public void testSomeMethod() {
-        // TODO review the generated test code and remove the default call to fail.
-        Password ppwd = new Password(0, "pass");
-        
-        assertTrue(ppwd.getPassword().equals("pass"));
+    public void testEquals() {
+        Password other = new Password(1, "abcd%123");
+        assertEquals(password, other);
+
+        other.setCategory(new Category());
+        assertNotEquals(password, other);
+
+        other = new Password(2, "abcd%123");
+        assertNotEquals(password, other);
+
+        other = new Password(1, "abcd%1234");
+        assertNotEquals(password, other);
     }
     
 }


### PR DESCRIPTION
Hello @rodi0878,

I found a potential problem.
Using _instanceof_ in the equals method could cause unexpected results when comparing subclasses.
In addition, the method is difficult to read. That is why I am proposing this update.