### PR TITLE
Implementation of the password validator

### DIFF
--- a/src/main/java/cz/upce/fei/inptp/zz/entity/PasswordDatabase.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/entity/PasswordDatabase.java
@@ -5,6 +5,7 @@
  */
 package cz.upce.fei.inptp.zz.entity;
 
+import cz.upce.fei.inptp.zz.service.password.PasswordValidatorServiceModule;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +28,13 @@ public class PasswordDatabase {
     }
 
     public void add(Password password) {
+        PasswordValidatorServiceModule passwordValidator = new PasswordValidatorServiceModule();
+        switch(passwordValidator.getPasswordStrength(password)) {
+            case WEAK:
+                System.out.println("Your password is too weak. Consider changing your password.");
+                break;
+        }
+        
         passwords.add(password);
     }
     

--- a/src/main/java/cz/upce/fei/inptp/zz/service/password/PasswordValidatorService.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/service/password/PasswordValidatorService.java
@@ -1,0 +1,22 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package cz.upce.fei.inptp.zz.service.password;
+
+import cz.upce.fei.inptp.zz.entity.Password;
+
+/**
+ *
+ * @author michc
+ */
+interface PasswordValidatorService {
+    PasswordStrength getPasswordStrength(Password password);
+}
+
+enum PasswordStrength {
+    STRONG,
+    NORMAL,
+    WEAK
+}

--- a/src/main/java/cz/upce/fei/inptp/zz/service/password/PasswordValidatorService.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/service/password/PasswordValidatorService.java
@@ -6,6 +6,7 @@
 package cz.upce.fei.inptp.zz.service.password;
 
 import cz.upce.fei.inptp.zz.entity.Password;
+import cz.upce.fei.inptp.zz.service.password.PasswordValidatorServiceModule.PasswordStrength;
 
 /**
  *
@@ -13,10 +14,4 @@ import cz.upce.fei.inptp.zz.entity.Password;
  */
 interface PasswordValidatorService {
     PasswordStrength getPasswordStrength(Password password);
-}
-
-enum PasswordStrength {
-    STRONG,
-    NORMAL,
-    WEAK
 }

--- a/src/main/java/cz/upce/fei/inptp/zz/service/password/PasswordValidatorServiceModule.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/service/password/PasswordValidatorServiceModule.java
@@ -1,0 +1,76 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package cz.upce.fei.inptp.zz.service.password;
+
+import cz.upce.fei.inptp.zz.entity.Password;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *
+ * @author michc
+ */
+public class PasswordValidatorServiceModule implements PasswordValidatorService {
+    private final Map<PasswordStrength, Integer> scoreLimits;
+
+    public PasswordValidatorServiceModule() {
+        scoreLimits = new HashMap<>();
+        scoreLimits.put(PasswordStrength.NORMAL, 4);
+        scoreLimits.put(PasswordStrength.STRONG, 6);
+    }
+    
+    /**
+     *
+     * @param password The password to get the strength of
+     * @return The strength of a password
+     */
+    @Override
+    public PasswordStrength getPasswordStrength(Password password) {
+        int score = getPasswordScore(password);
+        
+        if (score < scoreLimits.get(PasswordStrength.NORMAL)) {
+            return PasswordStrength.WEAK;
+        }
+        else if (score >= scoreLimits.get(PasswordStrength.NORMAL) && score <= scoreLimits.get(PasswordStrength.STRONG)) {
+            return PasswordStrength.NORMAL;
+        }
+        else {
+            return PasswordStrength.STRONG;
+        }
+    }
+    
+    private int getPasswordScore(Password password) {
+        int score = 0;
+        String passswordToValidate = password.getPassword();
+        
+        if (passswordToValidate.length() < 6) {
+            return 0;
+        } else if (passswordToValidate.length() < 10) {
+            score += 1;
+        }
+        else {
+            score += 2;
+        }
+        
+        if (RegularExpressionHandler.HasLowerCaseCharacters(passswordToValidate)) {
+            score += 1;
+        }
+        
+        if (RegularExpressionHandler.HasUpperCaseCharacters(passswordToValidate)) {
+            score += 1;
+        }
+        
+        if (RegularExpressionHandler.HasSpecialCharacters(passswordToValidate)) {
+            score += 2;
+        }
+        
+        if (RegularExpressionHandler.HasNumbers(passswordToValidate)) {
+            score += 1;
+        }
+        
+        return score;
+    }
+}

--- a/src/main/java/cz/upce/fei/inptp/zz/service/password/PasswordValidatorServiceModule.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/service/password/PasswordValidatorServiceModule.java
@@ -73,4 +73,10 @@ public class PasswordValidatorServiceModule implements PasswordValidatorService 
         
         return score;
     }
+    
+    public enum PasswordStrength {
+        STRONG,
+        NORMAL,
+        WEAK
+    }
 }

--- a/src/main/java/cz/upce/fei/inptp/zz/service/password/RegularExpressionHandler.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/service/password/RegularExpressionHandler.java
@@ -1,0 +1,33 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package cz.upce.fei.inptp.zz.service.password;
+
+/**
+ *
+ * @author michc
+ */
+public class RegularExpressionHandler {
+    private static final String LOWER_CASE_CHARACTER_REGULAR_EXPRESSION = "(?=.*[a-z])";
+    private static final String UPPER_CASE_CHARACTER_REGULAR_EXPRESSION = "(?=.*[A-Z])";
+    private static final String SPECIAL_CHARACTERS_REGULAR_EXPRESSION = "(?=.*[~!@#$%^&*()_-]).*";
+    private static final String NUMBERS_REGULAR_EXPRESSION = "(?=.*[0-9])";
+    
+    public static boolean HasLowerCaseCharacters(String text) {
+        return text.matches(LOWER_CASE_CHARACTER_REGULAR_EXPRESSION);
+    }
+    
+    public static boolean HasUpperCaseCharacters(String text) {
+        return text.matches(UPPER_CASE_CHARACTER_REGULAR_EXPRESSION);
+    }
+    
+    public static boolean HasNumbers(String text) {
+        return text.matches(NUMBERS_REGULAR_EXPRESSION);
+    }
+    
+    public static boolean HasSpecialCharacters(String text) {
+        return text.matches(SPECIAL_CHARACTERS_REGULAR_EXPRESSION);
+    }
+}

--- a/src/main/java/cz/upce/fei/inptp/zz/service/password/RegularExpressionHandler.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/service/password/RegularExpressionHandler.java
@@ -10,10 +10,10 @@ package cz.upce.fei.inptp.zz.service.password;
  * @author michc
  */
 public class RegularExpressionHandler {
-    private static final String LOWER_CASE_CHARACTER_REGULAR_EXPRESSION = "(?=.*[a-z])";
-    private static final String UPPER_CASE_CHARACTER_REGULAR_EXPRESSION = "(?=.*[A-Z])";
-    private static final String SPECIAL_CHARACTERS_REGULAR_EXPRESSION = "(?=.*[~!@#$%^&*()_-]).*";
-    private static final String NUMBERS_REGULAR_EXPRESSION = "(?=.*[0-9])";
+    private static final String LOWER_CASE_CHARACTER_REGULAR_EXPRESSION = ".*[a-z]+.*";
+    private static final String UPPER_CASE_CHARACTER_REGULAR_EXPRESSION = ".*[A-Z]+.*";
+    private static final String SPECIAL_CHARACTERS_REGULAR_EXPRESSION = ".*[~!@#$%^&*()_-]+.*";
+    private static final String NUMBERS_REGULAR_EXPRESSION = ".*[0-9]+.*";
     
     public static boolean HasLowerCaseCharacters(String text) {
         return text.matches(LOWER_CASE_CHARACTER_REGULAR_EXPRESSION);

--- a/src/test/java/cz/upce/fei/inptp/zz/password/PasswordValidatorServiceTest.java
+++ b/src/test/java/cz/upce/fei/inptp/zz/password/PasswordValidatorServiceTest.java
@@ -1,0 +1,36 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package cz.upce.fei.inptp.zz.password;
+
+import cz.upce.fei.inptp.zz.entity.Password;
+import cz.upce.fei.inptp.zz.service.password.PasswordValidatorServiceModule;
+import cz.upce.fei.inptp.zz.service.password.PasswordValidatorServiceModule.PasswordStrength;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author michc
+ */
+public class PasswordValidatorServiceTest {
+    @Test
+    public void getPasswordStrength() {
+        Password[] passwords = new Password[] {
+            new Password(0, "mypass"),
+            new Password(1, "MyPass"),
+            new Password(2, "MyPassword123"),
+            new Password(3, "0118999881990199725__3"),
+            new Password(4, "MyStr0ngP4ssw0rd__")
+        };
+        
+        PasswordValidatorServiceModule passwordValidator = new PasswordValidatorServiceModule();
+        assertEquals(PasswordStrength.WEAK, passwordValidator.getPasswordStrength(passwords[0]));
+        assertEquals(PasswordStrength.WEAK, passwordValidator.getPasswordStrength(passwords[1]));
+        assertEquals(PasswordStrength.WEAK, passwordValidator.getPasswordStrength(passwords[2]));
+        assertEquals(PasswordStrength.NORMAL, passwordValidator.getPasswordStrength(passwords[3]));
+        assertEquals(PasswordStrength.STRONG, passwordValidator.getPasswordStrength(passwords[4]));
+    }
+}

--- a/src/test/java/cz/upce/fei/inptp/zz/password/PasswordValidatorServiceTest.java
+++ b/src/test/java/cz/upce/fei/inptp/zz/password/PasswordValidatorServiceTest.java
@@ -29,7 +29,7 @@ public class PasswordValidatorServiceTest {
         PasswordValidatorServiceModule passwordValidator = new PasswordValidatorServiceModule();
         assertEquals(PasswordStrength.WEAK, passwordValidator.getPasswordStrength(passwords[0]));
         assertEquals(PasswordStrength.WEAK, passwordValidator.getPasswordStrength(passwords[1]));
-        assertEquals(PasswordStrength.WEAK, passwordValidator.getPasswordStrength(passwords[2]));
+        assertEquals(PasswordStrength.NORMAL, passwordValidator.getPasswordStrength(passwords[2]));
         assertEquals(PasswordStrength.NORMAL, passwordValidator.getPasswordStrength(passwords[3]));
         assertEquals(PasswordStrength.STRONG, passwordValidator.getPasswordStrength(passwords[4]));
     }


### PR DESCRIPTION
This patch is implementing password validator. This validator checks password strength, before it is going to be added to the database. Possible values of a password strength are: weak, normal or strong. The final value of password strength is calculated by the "strength score". 

The score of a password is calculated by following rules:
If password length is:
   lower than 6 - the password is immediately considered as weak
   even or higher 6 and lower than 10 - the score is increased by 1
   even or higher 10 - the score is increased by 2
If password contains:
   lower case characters - the score is increased by 1
   upper case characters - the score is increased by 1
   special characters - the score is increased by 2
   numbers - the score is increased by 1

If the score lower than 4, it is considered as weak. If the score is higher or even 4 and lower than 6, the strength of the password is considered as normal. Otherwise the password is considered as strong.
 
The patch also implements a test of the password strength evaluation.