### PR TITLE
Errors fixtures

### DIFF
--- a/src/main/java/cz/upce/fei/inptp/zz/controller/Main.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/controller/Main.java
@@ -46,6 +46,7 @@ public class Main {
         commandLineParser.parse(args);
 
         PasswordDatabaseService databaseService = InstanceInjector.injector().getInstance(PasswordDatabaseService.class);
+        PasswordDatabase passwordDatabase;
         switch(commandLineParser.getParsedCommand()){
             case ADD_COMMAND:
                 Password password = new Password.PasswordBuilder()
@@ -55,7 +56,7 @@ public class Main {
 
                 List<Password> pwds = Arrays.asList(password);
 
-                PasswordDatabase passwordDatabase = new PasswordDatabase.PasswordDatabaseBuilder()
+                passwordDatabase = new PasswordDatabase.PasswordDatabaseBuilder()
                         .setFile(new File("test.txt"))
                         .setPassword("password")
                         .setPasswords(pwds)
@@ -73,7 +74,7 @@ public class Main {
                 break;
             case EDIT_COMMAND:
                 try {
-                    PasswordDatabase passwordDatabase = databaseService.openPasswordDatabase(new File("test.txt"), "password");
+                    passwordDatabase = databaseService.openPasswordDatabase(new File("test.txt"), "password");
                     Password passwordToEdit = passwordDatabase.getPasswordById(editCommand.getId());
                     passwordDatabase.editPassword(passwordToEdit, editCommand.getNewValue().getPassword());
                     databaseService.savePasswordDatabase(passwordDatabase);
@@ -83,7 +84,7 @@ public class Main {
                 break;
             case DELETE_COMMAND:
                 try {
-                    PasswordDatabase passwordDatabase = databaseService.openPasswordDatabase(new File("test.txt"), "password");
+                    passwordDatabase = databaseService.openPasswordDatabase(new File("test.txt"), "password");
                     Password passwordToDelete = passwordDatabase.getPasswordById(editCommand.getId());
                     passwordDatabase.getPasswords().remove(passwordToDelete);
                     databaseService.savePasswordDatabase(passwordDatabase);

--- a/src/main/java/cz/upce/fei/inptp/zz/entity/PasswordDatabase.java
+++ b/src/main/java/cz/upce/fei/inptp/zz/entity/PasswordDatabase.java
@@ -67,6 +67,7 @@ public class PasswordDatabase {
         if (passwordToEdit != null && newPassword != null){
             passwordToEdit.setPassword(newPassword);
         }          
+    }
 
     public static class PasswordDatabaseBuilder {
         private File file;

--- a/src/test/java/cz/upce/fei/inptp/zz/entity/PasswordDatabaseTest.java
+++ b/src/test/java/cz/upce/fei/inptp/zz/entity/PasswordDatabaseTest.java
@@ -65,8 +65,11 @@ public class PasswordDatabaseTest {
 
     @Test
     public void getPasswordByIdTest() throws InvalidParameterException {
-        Password expectedPassword = new Password(2, "password3");
-
+        Password expectedPassword = new Password.PasswordBuilder()
+                        .setId(2)
+                        .setPassword("password3")
+                        .createPassword();
+        
         this.database.add(preparePassword(0, "password1", "email", "seznam.cz", "Password for my email"));
         this.database.add(preparePassword(1, "password2", "email", "gmail.com", "Password for my email"));
         this.database.add(preparePassword(2, "password3", "tiktok", "tiktok.com", "Password for social media"));
@@ -78,7 +81,10 @@ public class PasswordDatabaseTest {
     @Test
     public void editPasswordTest() {
         String expectedPassword = "Password";
-        Password password = new Password(0, "paswd");
+        Password password = new Password.PasswordBuilder()
+                        .setId(0)
+                        .setPassword("paswd")
+                        .createPassword();
         password.setPassword("Password");
         assertEquals(password.getPassword(), expectedPassword);
     }

--- a/src/test/java/cz/upce/fei/inptp/zz/entity/PasswordTest.java
+++ b/src/test/java/cz/upce/fei/inptp/zz/entity/PasswordTest.java
@@ -69,7 +69,10 @@ public class PasswordTest {
     @Test
     public void setPasswordTest(){
         String expectedPassword = "Password";
-        Password  password = new Password(0, "paswd");
+        Password password = new Password.PasswordBuilder()
+                        .setId(0)
+                        .setPassword("paswd")
+                        .createPassword();
         password.setPassword("Password");
         assertEquals(password.getPassword(), expectedPassword);
     }


### PR DESCRIPTION
Fixing several erros, which appeared after last patches probably. These fixtures contains:
Initialization of the Password objects by public constructor was replaced by initialization using PasswordBuilder object.
Missing parentheses in the PasswordDatabase class.
Multiple declaration of a passwordDatabase variable in the main method was replaced by a single one. 